### PR TITLE
No --outputLog now prints correct printType output to stdout

### DIFF
--- a/src/openSeaChest_LogParser.cpp
+++ b/src/openSeaChest_LogParser.cpp
@@ -589,10 +589,46 @@ int32_t main(int argc, char *argv[])
         {
 			std::string myFile = INPUT_LOG_FILE_NAME;				// myFile for the auto creation of the output file
 			myFile = myFile.substr(0, myFile.rfind("."));           // remove the extension from the file
-			myFile.append(".jsn");									// Auto add the jsn for json output file
-			CMessage *printMessage;
-			printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG);
-            std::cout << printMessage->get_Msg_JSON_Data().c_str();	// Print to the screen
+            CMessage *printMessage;
+            if (OUTPUT_LOG_PRINT_FLAG == SEAGATE_LOG_PRINT_JSON)         // Append output extension, .json by default
+            {
+                myFile.append(".json");
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get JSON output
+                std::cout << printMessage->get_Msg_JSON_Data().c_str();	// Print to the screen
+            }
+            else if (OUTPUT_LOG_PRINT_FLAG == SEAGATE_LOG_PRINT_TEXT)
+            {
+                myFile.append(".txt");
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get text output
+                printMessage->parse_Json_to_Text(masterJson, 0);
+                std::cout << printMessage->get_Msg_Text_Format("").c_str();	// Print to the screen
+            }
+            else if (OUTPUT_LOG_PRINT_FLAG == SEAGATE_LOG_PRINT_CSV)
+            {
+                myFile.append(".csv");
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get CSV output
+                std::cout << printMessage->get_Msg_CSV(masterJson).c_str();	// Print to the screen
+            }
+            else if (OUTPUT_LOG_PRINT_FLAG == SEAGATE_LOG_PRINT_FLAT_CSV)
+            {
+                myFile.append(".csv");
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get flat CSV output
+                std::cout << printMessage->get_Msg_Flat_csv(masterJson).c_str();	// Print to the screen
+            }
+            else if (OUTPUT_LOG_PRINT_FLAG == SEAGATE_LOG_PRINT_PROM)
+            {
+                myFile.append(".prom");
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get Prometheus output
+                printMessage->setSerialNumber(masterJson);
+                printMessage->parseJSONToProm(masterJson, printMessage->getSerialNumber(), NULL);
+                std::cout << printMessage->printProm().c_str();	// Print to the screen
+            }
+            else
+            {
+                myFile.append(".json");	
+                printMessage = new CMessage(masterJson, myFile, OUTPUT_LOG_PRINT_FLAG); // Get JSON output by default
+                std::cout << printMessage->get_Msg_JSON_Data().c_str();	// Print to the screen
+            }
             delete(printMessage);
         }
         json_delete(masterJson);


### PR DESCRIPTION
Running openSeaChest_LogParser without the `--outputLog` flag is intended to print the output to the screen. However, previously, running openSeaChest_LogParser without `--outputLog` would print the output in JSON format, regardless of whether or not a different print type (e.g. CSV or Text) was specified with `--printType`. Meanwhile, the correct format was set to a file with a .jsn file extension (even if the print type differed).

For example, running the LogParser with a CSV print type but no outputLog would result in JSON output being printed to the screen (stdout) and CSV output being sent to a .jsn file. The following image illustrates this.
![openSeaChest_LogParser-output_bug-csv](https://user-images.githubusercontent.com/16036780/98982789-83116c80-24e5-11eb-8a55-1e4df9d68e0c.png)

The desired output for such a situation would be CSV output printed to stdout (rather than JSON) and to a .csv file (rather than .jsn). My changes result in the following situation.
![openSeaChest_LogParser-output_bug-csv](https://user-images.githubusercontent.com/16036780/98982937-b7852880-24e5-11eb-999e-c927acf82a3c.png)

A similar situation could occur with the Prom print type. Currently, with `--printType prom`, JSON is printed to stdout, and Prom output is sent to a .jsn file.
![openSeaChest_LogParser-output_bug-prom](https://user-images.githubusercontent.com/16036780/98983116-f7e4a680-24e5-11eb-87f0-4e16a46bb84b.png)

My changes result in Prom printed to stdout and sent to a .prom file.
![openSeaChest_LogParser-output_bug-prom](https://user-images.githubusercontent.com/16036780/98983163-06cb5900-24e6-11eb-8c98-c2ee1f8a350c.png)

JSON is still used as the default if no print type is specified (just as before), so if JSON is specified as the print type or the argument is omitted, JSON is printed to stdout and to a .json file. The only difference is that the file extension was changed to .json, which is the proper extension according to the [RFC 8259 internet standard](https://tools.ietf.org/html/rfc8259).
![openSeaChest_LogParser-output_bug-default](https://user-images.githubusercontent.com/16036780/98983995-3333a500-24e7-11eb-8153-2e11ac8352c9.png)