### PR TITLE
Potential fix for code scanning alert no. 9: Redundant null check due to previous dereference

### DIFF
--- a/utils/src/parser_print_util_options.cpp
+++ b/utils/src/parser_print_util_options.cpp
@@ -1053,7 +1053,7 @@ void CPrintProm::parseJSONToProm(JSONNODE* nData, std::string inserialNumber, js
                 JSONNODE_ITERATOR it_jsonArrayNode = json_begin(*it_jsonArray);
                 json_char *jsonArrayNodeName = json_name(*it_jsonArrayNode);
                 // Do nothing if the node is NULL
-                if (it_jsonArrayNode == M_NULLPTR || jsonArrayNodeName == M_NULLPTR)
+                if (jsonArrayNodeName == M_NULLPTR)
                 {
                     json_free(jsonArrayNodeName);
                     json_free(jsonArrayName);


### PR DESCRIPTION
Potential fix for [https://github.com/Seagate/openSeaChest_LogParser/security/code-scanning/9](https://github.com/Seagate/openSeaChest_LogParser/security/code-scanning/9)

In general, this kind of problem is fixed by making sure any pointer or iterator is validated (checked for null / invalid state) before it is dereferenced, or by removing an impossible/null check if the value is guaranteed non-null. Here, `it_jsonArrayNode` is dereferenced at line 1054 and then checked against `M_NULLPTR` at line 1056; that specific null check can never protect the earlier dereference. The rest of the logic (checking `jsonArrayNodeName` for null, freeing resources, and breaking) appears intentional and should be preserved.

The minimal, behavior-preserving fix within the shown code is to remove the redundant `it_jsonArrayNode == M_NULLPTR` part of the condition at line 1056, leaving only the check on `jsonArrayNodeName`. That way, CodeQL’s “redundant null check due to previous dereference” warning is resolved, while the code still guards against the case where `json_name` returns `M_NULLPTR`. We do not move the check earlier or change the control flow, because we cannot safely assume or redesign how `JSONNODE_ITERATOR` and `json_begin` behave without seeing the surrounding library usage. No new imports, methods, or definitions are needed; this is a one-line logical change in `utils/src/parser_print_util_options.cpp`.

Concretely:
- In `CPrintProm::parseJSONToProm`, in the branch handling `JSON_NODE` inside an array (`else if (json_type(*it_jsonArray) == JSON_NODE)`), replace the condition
  `if (it_jsonArrayNode == M_NULLPTR || jsonArrayNodeName == M_NULLPTR)`
  with
  `if (jsonArrayNodeName == M_NULLPTR)`.
All other lines (including resource freeing and recursion) remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
